### PR TITLE
Fix init function to work with pending changes

### DIFF
--- a/dbsync.py
+++ b/dbsync.py
@@ -486,9 +486,10 @@ def dbsync_init(mc, from_gpkg=True):
                                                  config.db_conn_info, config.db_schema_modified)
             summary_base = _compare_datasets("sqlite", "", gpkg_full_path, config.db_driver,
                                              config.db_conn_info, config.db_schema_base)
-            if len(summary_base):
-                raise DbSyncError("The db schemas already exist but 'base' schema is not synchronized with source GPKG")
-            elif len(summary_modified):
+            if len(summary_base) and not len(summary_modified):
+                raise DbSyncError("The db schemas already exist but 'base' schema is not synchronized with source GPKG "
+                                  "while modified schema is up to date")
+            if len(summary_modified):
                 print("Modified schema is not synchronised with source GPKG, please run pull/push commands to fix it")
                 return
             else:
@@ -518,8 +519,9 @@ def dbsync_init(mc, from_gpkg=True):
                                                 "sqlite", "", gpkg_full_path, config.db_driver)
             summary_base = _compare_datasets(config.db_conn_info, config.db_schema_base,
                                             "sqlite", "", gpkg_full_path, config.db_driver)
-            if len(summary_base):
-                raise DbSyncError("The output GPKG file exists already but it is not synchronized with db 'base' schema")
+            if len(summary_base) and not len(summary_modified):
+                raise DbSyncError("The output GPKG file exists already but it is not synchronized with db 'base' "
+                                  "schema while being synchronized with modified schema")
             elif len(summary_modified):
                 print("The output GPKG file exists already but it is not synchronised with modified schema, "
                       "please run pull/push commands to fix it")

--- a/dbsync.py
+++ b/dbsync.py
@@ -487,10 +487,17 @@ def dbsync_init(mc, from_gpkg=True):
             summary_base = _compare_datasets("sqlite", "", gpkg_full_path, config.db_driver,
                                              config.db_conn_info, config.db_schema_base)
             if len(summary_base) and not len(summary_modified):
+                # seems someone modified base schema manually - this should never happen!
                 raise DbSyncError("The db schemas already exist but 'base' schema is not synchronized with source GPKG "
                                   "while modified schema is up to date")
-            if len(summary_modified):
+            elif len(summary_modified) and not len(summary_base):
                 print("Modified schema is not synchronised with source GPKG, please run pull/push commands to fix it")
+                return
+            elif len(summary_modified) and len(summary_base):
+                # here we are not sure whether base schema changes are safe (e.g. higher server version of project)
+                # or someone modified base schema manually which should not happen!
+                print("Both modified and base schemas are not synchronised with source GPKG, "
+                      "beware that bad things could happen")
                 return
             else:
                 print("The GPKG file, base and modified schemas are already initialized and in sync")
@@ -522,9 +529,13 @@ def dbsync_init(mc, from_gpkg=True):
             if len(summary_base) and not len(summary_modified):
                 raise DbSyncError("The output GPKG file exists already but it is not synchronized with db 'base' "
                                   "schema while being synchronized with modified schema")
-            elif len(summary_modified):
+            elif len(summary_modified) and not len(summary_base):
                 print("The output GPKG file exists already but it is not synchronised with modified schema, "
                       "please run pull/push commands to fix it")
+                return
+            elif len(summary_modified) and len(summary_base):
+                print("The output GPKG file exists already but both modified and base schemas are not synchronised it, "
+                      "beware that bad things could happen")
                 return
             else:
                 print("The GPKG file, base and modified schemas are already initialized and in sync")

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -107,9 +107,9 @@ def test_init_from_gpkg(mc):
     dbsync_init(mc, from_gpkg=True)
     cur.execute(f"SELECT count(*) from {db_schema_main}.simple")
     assert cur.fetchone()[0] == 3
-    proj, version = _get_db_project_comment(conn, db_schema_base)
-    assert proj == config.mergin_project_name
-    assert version == 'v1'
+    db_proj_info = _get_db_project_comment(conn, db_schema_base)
+    assert db_proj_info["name"] == config.mergin_project_name
+    assert db_proj_info["version"] == 'v1'
 
     # rename base schema to mimic some mismatch
     cur.execute(f"ALTER SCHEMA {db_schema_base} RENAME TO schema_tmp")
@@ -205,8 +205,8 @@ def test_basic_pull(mc):
     cur = conn.cursor()
     cur.execute("SELECT count(*) from test_sync_pull_main.simple")
     assert cur.fetchone()[0] == 4
-    proj, version = _get_db_project_comment(conn, 'test_sync_pull_base')
-    assert version == 'v2'
+    db_proj_info = _get_db_project_comment(conn, 'test_sync_pull_base')
+    assert db_proj_info["version"] == 'v2'
 
     print("---")
     dbsync_status(mc)
@@ -237,8 +237,8 @@ def test_basic_push(mc):
 
     # push the change from DB to PostgreSQL
     dbsync_push(mc)
-    proj, version = _get_db_project_comment(conn, 'test_sync_push_base')
-    assert version == 'v2'
+    db_proj_info = _get_db_project_comment(conn, 'test_sync_push_base')
+    assert db_proj_info["version"] == 'v2'
 
     # pull new version of the project to the work project directory
     mc.pull_project(project_dir)
@@ -285,11 +285,11 @@ def test_basic_both(mc):
 
     # first pull changes from Mergin to DB (+rebase changes in DB) and then push the changes from DB to Mergin
     dbsync_pull(mc)
-    proj, version = _get_db_project_comment(conn, 'test_sync_both_base')
-    assert version == 'v2'
+    db_proj_info = _get_db_project_comment(conn, 'test_sync_both_base')
+    assert db_proj_info["version"] == 'v2'
     dbsync_push(mc)
-    proj, version = _get_db_project_comment(conn, 'test_sync_both_base')
-    assert version == 'v3'
+    db_proj_info = _get_db_project_comment(conn, 'test_sync_both_base')
+    assert db_proj_info["version"] == 'v3'
 
     # pull new version of the project to the work project directory
     mc.pull_project(project_dir)


### PR DESCRIPTION
The issue originates from local gpkg file being lost after docker restart. In case of file server version update there will always be some pending changes.
Actual error should be thrown only in case that geopackage and modified schema are synchronized but base schema is not (e.g. patched manually by mistake)