### PR TITLE
added rm to get rid of container after exit or unsuccessful execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The easiest way to run DB sync is with Docker.
 
 To build the container:
 ```
-docker build -t mergin_db_sync .
+docker build -t mergin-db-sync .
 ```
 
 To run the container, use a command like the following one: 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -29,7 +29,7 @@ and your full project name for later will be `<username>/<project-name>`, e.g. `
 Download and run db-sync docker image:
 
 ```
-$ sudo docker run --name mergin_db_sync -it \
+$ sudo docker run --rm --name mergin_db_sync -it \
   -e DB_CONN_INFO="host=myhost.com dbname=db-sync user=postgres password=top_secret" \
   -e DB_SCHEMA_MODIFIED=sync_data \
   -e DB_SCHEMA_BASE=sync_base \


### PR DESCRIPTION
it is an annoyance to run `docker container rm xxxfsdfgsdfsd` any time the docker cannot execute or user exits. This will clean the container after exit: https://docs.docker.com/engine/reference/run/#clean-up---rm