### PR TITLE
Stop caching MerginProjects, since that's now done by the client library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mergin-client==0.9.0
+mergin-client==0.12.0
 dynaconf>=3.1
 psycopg2>=2.9


### PR DESCRIPTION
This PR is a follow-up to https://github.com/MerginMaps/python-api-client/pull/283, which moved the caching into the client library.

This fixes a bug where due to using stale metadata in one MerginProject instance, the initial init and sync was unable to complete.