### PR TITLE
Re-read MerginProject state on creation/reuse

### DIFF
--- a/dbsync.py
+++ b/dbsync.py
@@ -536,6 +536,10 @@ def _get_mergin_project(work_path) -> MerginProject:
     """
     if work_path not in cached_mergin_project_objects:
         cached_mergin_project_objects[work_path] = MerginProject(work_path)
+    # Clear metadata so we re-read the state.
+    # This is needed since otherwise we can have multiple MerginProject
+    # instances of the same workpath with different state.
+    cached_mergin_project_objects[work_path]._metadata = None
     cached_mergin_project_objects[work_path]._read_metadata()
     return cached_mergin_project_objects[work_path]
 


### PR DESCRIPTION
This fixes the same issue as #169, but since that relies on changes to the client library that don't look like they'll be released soon, this fixes it inside db-sync in a less efficient way.